### PR TITLE
Allow blank credentials to push to public LRS

### DIFF
--- a/Tools/StatementGenerator/js/statements.js
+++ b/Tools/StatementGenerator/js/statements.js
@@ -1280,13 +1280,18 @@ $("#clear-deleted-documents").click(function(e) {
 $("#endpoint-values").validator();
 
 // Update statement viewer links to pass auth via query string
-$("#endpoint-values").keyup(function() {
+$("#endpoint-values").keyup(function () {
     var root = $(".statement-viewer").attr("rel");
     console.log(root);
     var endpoint = $("#endpoint").val();
     var username = $("#username").val();
     var password = $("#password").val();
+    if (password == null && username == null) {
+        var username = "xapi-tools";
+        var password = "xapi-tools";
+    }
     var auth = "Basic%20" + toBase64(username + ":" + password);
+    
     $(".statement-viewer").attr("href", root + "?endpoint=" + endpoint + "&auth=" + auth);
 });
 
@@ -1337,6 +1342,12 @@ function setupConfig() {
     var endpoint = $("#endpoint").val();
     var user = $("#username").val();
     var password = $("#password").val();
+
+    if (password == "" || user == "") {
+        
+        user = "xapi-tools";
+        password = "xapi-tools";
+    }
 
     var conf = {
         "endpoint" : endpoint,


### PR DESCRIPTION
If user has blank credentials, will push to xapi-tools acct
added to allow for html removing credentials from plaintext